### PR TITLE
feat: Eco in Gradle Properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 group = "com.willfp"
 version = findProperty("version")!!
 val libreforgeVersion = findProperty("libreforge-version")
+val ecoVersion = findProperty("eco-version")
 
 base {
     archivesName.set(project.name)
@@ -39,7 +40,7 @@ allprojects {
     }
 
     dependencies {
-        compileOnly("com.willfp:eco:7.6.0")
+        compileOnly("com.willfp:eco:$ecoVersion")
         compileOnly("org.jetbrains:annotations:26.0.2")
         compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.3.0")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,5 @@
 #Sat May 23 13:07:06 BST 2026
 kotlin.code.style=official
 libreforge-version=5.5.0
+eco-version=7.6.0
 version=7.6.0


### PR DESCRIPTION
Moves eco dependency version from hardcoded value in `build.gradle.kts` to `gradle.properties` as `eco-version`, following the same pattern as `libreforge-version`.